### PR TITLE
ver-1-view category

### DIFF
--- a/src/main/java/com/TechConnecGrupo3/TechConnec_api/api/CategoryController.java
+++ b/src/main/java/com/TechConnecGrupo3/TechConnec_api/api/CategoryController.java
@@ -1,0 +1,45 @@
+package com.TechConnecGrupo3.TechConnec_api.api;
+import java.util.List;
+
+import com.TechConnecGrupo3.TechConnec_api.dto.CategoryDTO;
+import com.TechConnecGrupo3.TechConnec_api.service.AdminCreateCategory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import lombok.AllArgsConstructor;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/category")
+public class CategoryController {
+    private final AdminCreateCategory adminCreateCategory;
+
+    @PostMapping("/create")
+    public ResponseEntity<CategoryDTO> addCategory(@RequestBody CategoryDTO categoryDTO){
+        try{
+            CategoryDTO newCategory = adminCreateCategory.addCategory(categoryDTO);
+            return new ResponseEntity<>(newCategory, HttpStatus.CREATED);
+        } catch (IllegalStateException sms) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @GetMapping("/list")
+    public List<CategoryDTO> getAllCategory() {
+        return adminCreateCategory.getAllCategory();
+    }
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Integer id) {
+        adminCreateCategory.delete(id);
+    }
+
+}
+

--- a/src/main/java/com/TechConnecGrupo3/TechConnec_api/dto/CategoryDTO.java
+++ b/src/main/java/com/TechConnecGrupo3/TechConnec_api/dto/CategoryDTO.java
@@ -30,4 +30,5 @@ public class CategoryDTO {
     public void setDescription(String description) {
         this.description = description;
     }
+    public Integer getEventsByCategory(){return categoryId; }
 }

--- a/src/main/java/com/TechConnecGrupo3/TechConnec_api/dto/EventDTO.java
+++ b/src/main/java/com/TechConnecGrupo3/TechConnec_api/dto/EventDTO.java
@@ -22,7 +22,7 @@ public class EventDTO {
     private LocalDateTime updatedAt;
 
     // Getters and Setters
-    public Integer getEventId() {
+    public Integer getCategory_id() {
         return eventId;
     }
 

--- a/src/main/java/com/TechConnecGrupo3/TechConnec_api/repository/CategoryRepository.java
+++ b/src/main/java/com/TechConnecGrupo3/TechConnec_api/repository/CategoryRepository.java
@@ -1,0 +1,15 @@
+package com.TechConnecGrupo3.TechConnec_api.repository;
+import com.TechConnecGrupo3.TechConnec_api.dto.CategoryDTO;
+import com.TechConnecGrupo3.TechConnec_api.dto.EventDTO;
+import com.TechConnecGrupo3.TechConnec_api.model.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Integer> {
+    List<Category> findAll();
+    Category findByName(String name);
+    List<EventDTO> getEventsByCategory (Integer categoryId);
+}
+

--- a/src/main/java/com/TechConnecGrupo3/TechConnec_api/service/AdminCreateCategory.java
+++ b/src/main/java/com/TechConnecGrupo3/TechConnec_api/service/AdminCreateCategory.java
@@ -1,0 +1,20 @@
+package com.TechConnecGrupo3.TechConnec_api.service;
+import com.TechConnecGrupo3.TechConnec_api.dto.CategoryDTO;
+import com.TechConnecGrupo3.TechConnec_api.dto.EventDTO;
+import com.TechConnecGrupo3.TechConnec_api.model.entity.Category;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public interface AdminCreateCategory {
+    Category create(Category category);
+    Category update(Integer id, Category updatedCategory);
+    void delete(Integer id);
+    List<Category> findAll();
+    Category findById(Integer id);
+    CategoryDTO addCategory(CategoryDTO categoryDTO);
+    List<CategoryDTO> getAllCategory();
+    CategoryDTO mapToDTO(Category category);
+    List<EventDTO> getEventsByCategory(Integer categoryId);
+}

--- a/src/main/java/com/TechConnecGrupo3/TechConnec_api/service/impl/AdminCreateCategoryImpl.java
+++ b/src/main/java/com/TechConnecGrupo3/TechConnec_api/service/impl/AdminCreateCategoryImpl.java
@@ -1,0 +1,85 @@
+package com.TechConnecGrupo3.TechConnec_api.service.impl;
+import com.TechConnecGrupo3.TechConnec_api.dto.CategoryDTO;
+import com.TechConnecGrupo3.TechConnec_api.dto.EventDTO;
+import com.TechConnecGrupo3.TechConnec_api.model.entity.Category;
+import com.TechConnecGrupo3.TechConnec_api.repository.CategoryRepository;
+import com.TechConnecGrupo3.TechConnec_api.service.AdminCreateCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminCreateCategoryImpl implements AdminCreateCategory {
+    private final CategoryRepository categoryRepository;
+
+
+    @Override
+    @Transactional
+    public Category create(Category category) {
+        if (category.getName() == null || category.getName().isEmpty()) {
+            throw new RuntimeException("El nombre de la categoría no puede estar vacío");
+        }
+        if (categoryRepository.findByName(category.getName()) != null) {
+            throw new RuntimeException("El nombre de la categoría ya existe");
+        }
+        return categoryRepository.save(category);
+    }
+
+    @Override
+    @Transactional
+    public Category update(Integer id, Category updatedCategory) {
+        Category categoryFromDb = findById(id);
+        categoryFromDb.setName(updatedCategory.getName());
+        categoryFromDb.setDescription(updatedCategory.getDescription());
+        return categoryRepository.save(categoryFromDb);
+    }
+    @Override
+    public CategoryDTO addCategory(CategoryDTO categoryDTO) {
+        try {
+            Category category = new Category();
+            category.setName(categoryDTO.getName());
+            category.setDescription(categoryDTO.getDescription());
+            Category createdCategory = create(category);
+            return mapToDTO(createdCategory);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+    @Override
+    @Transactional
+    public CategoryDTO mapToDTO(Category category) {
+        CategoryDTO categoryDTO = new CategoryDTO();
+        categoryDTO.setCategoryId(category.getCategory_id());
+        categoryDTO.setName(category.getName());
+        categoryDTO.setDescription(category.getDescription());
+        return categoryDTO;
+    }
+    @Override
+    @Transactional
+    public void delete(Integer id) {
+        categoryRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Category> findAll() {
+        return categoryRepository.findAll();
+    }
+    @Override
+    public List<EventDTO> getEventsByCategory (Integer categoryId){
+        return categoryRepository.getEventsByCategory(categoryId);
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public Category findById(Integer id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Categoría no encontrada con id: " + id));
+    }
+    @Override
+    public List<CategoryDTO> getAllCategory() {
+        return List.of();
+    }
+}


### PR DESCRIPTION
El usuario quiere  ver todas las categorías existentes en la plataforma, para organizar los eventos y facilitar la búsqueda.Crear un endpoint para manejar la solicitud GET a /categories es fundamental para proporcionar una lista de todas las categorías disponibles en la plataforma. La ruta debe ser capaz de consultar la base de datos y devolver la lista de categorías al frontend con los detalles correspondientes.