### PR TITLE
v0.0.0.1-Share event

### DIFF
--- a/src/main/java/com/TechConnecGrupo3/TechConnec_api/api/EventController.java
+++ b/src/main/java/com/TechConnecGrupo3/TechConnec_api/api/EventController.java
@@ -36,4 +36,35 @@ public class EventController {
     public List<Event> listAll() {
         return adminEventService.findAll();
     }
+    @GetMapping("/{id}/share")
+    public ResponseEntity<String> shareEvent(@PathVariable Integer id) {
+        Event event = adminEventService.findById(id);
+        if (event != null) {
+            String shareLink = "https://example.com/events/" + id;
+            return ResponseEntity.ok(shareLink);
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+    }
+
+    @GetMapping("/{id}/share/social")
+    public ResponseEntity<String> shareEventSocial(@PathVariable Integer id) {
+        Event event = adminEventService.findById(id);
+        if (event != null) {
+            String shareLink = "https://example.com/events/" + id;
+            String socialMediaLink = "https://www.facebook.com/sharer/sharer.php?u=" + shareLink;
+            return ResponseEntity.ok(socialMediaLink);
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+    }
+    @GetMapping("/{id}")
+    public ResponseEntity<Event> findById(@PathVariable Integer id) {
+        Event event = adminEventService.findById(id);
+        if (event != null) {
+            return ResponseEntity.ok(event);
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+    }
 }

--- a/src/main/java/com/TechConnecGrupo3/TechConnec_api/repository/EventRepository.java
+++ b/src/main/java/com/TechConnecGrupo3/TechConnec_api/repository/EventRepository.java
@@ -3,8 +3,10 @@ package com.TechConnecGrupo3.TechConnec_api.repository;
 import com.TechConnecGrupo3.TechConnec_api.model.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 public interface EventRepository extends JpaRepository<Event, Integer> {
-
+    List<Event> findAll();
 }
 

--- a/src/main/java/com/TechConnecGrupo3/TechConnec_api/service/impl/AdminEventServiceImpl.java
+++ b/src/main/java/com/TechConnecGrupo3/TechConnec_api/service/impl/AdminEventServiceImpl.java
@@ -4,6 +4,7 @@ import com.TechConnecGrupo3.TechConnec_api.model.entity.Event;
 import com.TechConnecGrupo3.TechConnec_api.repository.EventRepository;
 import com.TechConnecGrupo3.TechConnec_api.service.AdminEventService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,7 +13,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class AdminEventServiceImpl implements AdminEventService {
-
+    @Autowired
     private final EventRepository eventRepository;
 
     @Override
@@ -24,15 +25,13 @@ public class AdminEventServiceImpl implements AdminEventService {
     @Override
     @Transactional(readOnly = true)
     public Event findById(Integer id) {
-        return eventRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Event not found with id: " + id));
+        return eventRepository.findById(id).orElse(null);
     }
 
     @Override
     @Transactional
     public Event update(Integer id, Event updatedEvent) {
         Event eventFromDb = findById(id);
-
         eventFromDb.setTitle(updatedEvent.getTitle());
         eventFromDb.setDescription(updatedEvent.getDescription());
         eventFromDb.setLocation(updatedEvent.getLocation());
@@ -42,7 +41,16 @@ public class AdminEventServiceImpl implements AdminEventService {
 
         return eventRepository.save(eventFromDb);
     }
-
+    @Transactional
+    public String shareEvent(Integer id) {
+        Event event = findById(id);
+        if (event != null) {
+            String shareLink = "https://example.com/events/" + id;
+            return shareLink;
+        } else {
+            return null;
+        }
+    }
     @Override
     public List<Event> findAll() {
         return eventRepository.findAll();


### PR DESCRIPTION
El usuario, quiero poder compartir el enlace de un evento para enviárselo a personas interesadas en participar.Este endpoint es utilizado para recuperar los detalles de un evento específico, incluyendo su nombre, descripción y URL. La respuesta es un objeto JSON que contiene los detalles del evento.